### PR TITLE
s15g485 #1 vagrantファイル変更

### DIFF
--- a/vagrant/s15g485/Vagrantfile
+++ b/vagrant/s15g485/Vagrantfile
@@ -1,0 +1,12 @@
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.configure VAGRANTFILE_API_VERSION do |config|
+  config.vm.box = 'ubuntu/trusty64'
+  config.vm.hostname = 's15g485'
+  config.vm.network :public_network, ip: '192.168.11.44', bridge: 'eth1'
+
+  config.vm.provider :virtualbox do |v|
+    v.memory = 1024
+    v.cpus = 1
+  end
+end


### PR DESCRIPTION
# Vagrant 入門

Vagrantfileを編集し，VMの作成，起動，終了の方法を行った．
ネットワーク認証を避けるため，rookieのVMは最所研のローカルネットワークに接続させている．