### PR TITLE
refs #28 Ansibleを使ったApacheインストール

### DIFF
--- a/vagrant/s13t232/Vagrantfile
+++ b/vagrant/s13t232/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure VAGRANTFILE_API_VERSION do |config|
     v.cpus = 1
   end
 
-#  config.vm.provision 'ansible' do |ansible|
-#    ansible.playbook = '../ansible/main.yml'
-#  end
+  config.vm.provision 'ansible' do |ansible|
+    ansible.playbook = 'apache.yml'
+  end
 end

--- a/vagrant/s13t232/apache.yml
+++ b/vagrant/s13t232/apache.yml
@@ -1,0 +1,10 @@
+---
+- hosts: all
+  sudo: yes
+  gather_facts: yes
+  tasks:
+    - debug: msg="hostname = {{ ansible_hostname }}"
+    - debug: msg="eth1.ipv4.address = {{ ansible_eth1.ipv4.address }}"
+    - apt: name="apache2"
+    - service: name="apache2" state="reloaded"
+    - shell: echo "glassdog" > /var/www/html/index.html


### PR DESCRIPTION
Apacheの再起動をする際、
-service: name=apache2 state=reloaded
について、apache2 や reloaded をダブルクォーテーションで括っているサイトと括っていないサイトがあり、
どちらにしたものか迷った。
ダブルクォーテーションを付けてプロビジョニングすると、うまくいった。