### PR TITLE
s13t232 #40

### DIFF
--- a/vagrant/s13t232/apache.yml
+++ b/vagrant/s13t232/apache.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
+  vars:
+      http_port: 80
   sudo: yes
   gather_facts: yes
   tasks:
@@ -9,3 +11,4 @@
     - service: name="apache2" state="reloaded"
     - shell: echo "glassdog" > /var/www/html/index.html
     - template: src=index.html.j2 dest=/var/www/html/index.html
+    - include: editor.yml

--- a/vagrant/s13t232/editor.yml
+++ b/vagrant/s13t232/editor.yml
@@ -1,0 +1,3 @@
+---
+- apt: name=vim update_cache=yes state=latest
+- copy: src=/home/konyou/dotfiles/.vimrc dest=/home/vagrant/.vimrc

--- a/vagrant/s13t232/index.html.j2
+++ b/vagrant/s13t232/index.html.j2
@@ -6,6 +6,7 @@
 <body>
     <h1>{{ template_host }}</h1>
     <h1>{{ ansible_eth1.ipv4.address }}</h1>
+    <h1>http_port:{{ http_port }}</h1>
     {% for i in ansible_interfaces  %}
     <tr>
         <td>{{ loop.index0 }}</td>


### PR DESCRIPTION
copyモジュールを使って .vimrc を転送する際、etc=~/dotfiles/.vimrc と記述していたが、この記法では
正しく転送できなかった。 etc=/home/konyou/.vimrc とすることで、転送することができた。