### PR TITLE
refs #48 Itamaeのテンプレート機能

### DIFF
--- a/vagrant/s13t232/Vagrantfile
+++ b/vagrant/s13t232/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure VAGRANTFILE_API_VERSION do |config|
 
   config.vm.provision :itamae do |itamae|
     itamae.sudo = true
+    itamae.shell = '/bin/sh'
     itamae.recipes = ['apache.rb']
   end
 end

--- a/vagrant/s13t232/apache.rb
+++ b/vagrant/s13t232/apache.rb
@@ -7,3 +7,12 @@ end
 execute 'echo s13t232 > /var/www/html/index.html' do
     only_if "test -e /var/www/html/index.html"
 end
+
+template "/var/www/html/index.html" do
+    action :create
+    user 'root'
+    group 'root'
+    path '/var/www/html/index.html'
+    mode '644'
+    source 'index.html.erb'
+end

--- a/vagrant/s13t232/index.html.erb
+++ b/vagrant/s13t232/index.html.erb
@@ -1,0 +1,5 @@
+<% for n in 1..3 do %>
+    <% if n == 1 || n == 2 %>
+        Hello, <%= node['hostname'] %>
+    <% end %>
+<% end %>


### PR DESCRIPTION
当初、作成した index.html のパーミッションが600になっており、権限がなかったため curl で中身を
見ることができなかった。この問題は、apache.rbで権限を644に設定することで解決した。
次に、ホスト名の表示方法に悩んだが、node['hostname'] を使うことを知り、これを用いると表示
することができた。